### PR TITLE
FE에서 컨트랙트 호출하도록 리펙토링

### DIFF
--- a/src/main/java/TokenUs/TokenUs_BE/controller/NftController.java
+++ b/src/main/java/TokenUs/TokenUs_BE/controller/NftController.java
@@ -50,6 +50,16 @@ public class NftController {
         return nftService.mintVideoNFT(request, user);
     }
 
+    @PostMapping("/mint_result")
+    @Operation(
+            summary = "nft 발행 결과를 반환합니다.",
+            description =
+                    "FE에서 메타마스크로 스마트 컨트랙트 호출 후, 발행 결과를 확인하기 위해 사용합니다.</br> tokenId 리스트는 컨트랙트의 로그에서 추출해야합니다.</br> creatorId는 프런트에서 넣어주세요.")
+    public NftResponseDTO.NFTMintResultDTO mintResultGet(
+            @Validated @RequestBody NftRequestDTO.NFTMintRequestGetDTO request) throws Exception {
+        return nftService.mintResultGet(request);
+    }
+
     @PostMapping("/list")
     @Operation(
             summary = "nft를 마켓 플레이스에 등록",

--- a/src/main/java/TokenUs/TokenUs_BE/controller/NftController.java
+++ b/src/main/java/TokenUs/TokenUs_BE/controller/NftController.java
@@ -76,6 +76,20 @@ public class NftController {
         }
     }
 
+    @PostMapping("/list_result")
+    @Operation(
+            summary = "nft 판매 등록 결과를 반환합니다.",
+            description = "FE에서 메타마스크로 스마트 컨트랙트 호출 후, 판매 등록 결과를 확인하기 위해 사용합니다.</br>")
+    public ApiResponse<NftResponseDTO.NFTListResultDTO> listNFTResultGet(
+            @Validated @RequestBody NftRequestDTO.listNftResultGetDTO request) {
+        try {
+            NftResponseDTO.NFTListResultDTO result = nftService.listNftResultGet(request);
+            return ApiResponse.onSuccess(result);
+        } catch (Exception e) {
+            return ApiResponse.onFailure("LIST_RESULT_FAIL", e.getMessage(), null);
+        }
+    }
+
     @GetMapping("/listed")
     @Operation(
             summary = "판매 등록된 NFT 리스트 반환",
@@ -110,6 +124,20 @@ public class NftController {
             @AuthenticationPrincipal CustomUserDetails userDetails)
             throws Exception {
         return ApiResponse.onSuccess(nftService.delistNFT(request, userDetails.getUser().getId()));
+    }
+
+    @PostMapping("/delist_result")
+    @Operation(
+            summary = "nft 판매 등록 취소 결과를 반환합니다.",
+            description = "FE에서 메타마스크로 스마트 컨트랙트 호출 후, 판매 등록 결과를 확인하기 위해 사용합니다.</br>")
+    public ApiResponse<NftResponseDTO.NFTListResultDTO> delistNFTResultGet(
+            @Validated @RequestBody NftRequestDTO.listNftResultGetDTO request) {
+        try {
+            NftResponseDTO.NFTListResultDTO result = nftService.delistNftResultGet(request);
+            return ApiResponse.onSuccess(result);
+        } catch (Exception e) {
+            return ApiResponse.onFailure("LIST_RESULT_FAIL", e.getMessage(), null);
+        }
     }
 
     @PostMapping("/trade")

--- a/src/main/java/TokenUs/TokenUs_BE/controller/NftController.java
+++ b/src/main/java/TokenUs/TokenUs_BE/controller/NftController.java
@@ -150,6 +150,21 @@ public class NftController {
                 nftService.purchaseNFT(request, userDetails.getUser().getId()));
     }
 
+    @PostMapping("/trade_result")
+    @Operation(
+            summary = "NFT 거래 결과를 반환합니다.",
+            description = "FE에서 메타마스크로 스마트 컨트랙트 호출 후, 거래 결과를 확인하기 위해 사용합니다.</br>")
+    public ApiResponse<NftResponseDTO.NFTPurchaseResultGetDTO> purchaseNFTResultGet(
+            @Validated @RequestBody NftRequestDTO.NFTPurchaseResultGetDTO request) {
+        try {
+            NftResponseDTO.NFTPurchaseResultGetDTO result =
+                    nftService.purchaseNftResultGet(request);
+            return ApiResponse.onSuccess(result);
+        } catch (Exception e) {
+            return ApiResponse.onFailure("TRADE_RESULT_FAIL", e.getMessage(), null);
+        }
+    }
+
     @GetMapping("/trade_history")
     @Operation(
             summary = "videoId로 NFT 거래 내역을 조회합니다.",

--- a/src/main/java/TokenUs/TokenUs_BE/controller/VideoController.java
+++ b/src/main/java/TokenUs/TokenUs_BE/controller/VideoController.java
@@ -183,32 +183,49 @@ public class VideoController {
         return ApiResponse.onSuccess(result);
     }
 
-    @PatchMapping("/to_open")
-    @Operation(summary = "비디오를 비공개에서 공개로 전환", description = "")
-    public ApiResponse<VideoResponseDTO.openResultDTO> toOpenVideo(
+    //    @PatchMapping("/to_open")
+    //    @Operation(summary = "비디오를 비공개에서 공개로 전환", description = "")
+    //    public ApiResponse<VideoResponseDTO.openResultDTO> toOpenVideo(
+    //            @AuthenticationPrincipal CustomUserDetails userDetails,
+    //            @RequestParam(required = true) Long videoId) {
+    //        // 현재 로그인한 사용자가 크리에이터가 맞는지 확인
+    //        User user = userDetails.getUser();
+    //
+    //        Video video = videoService.openVideo(videoId, user);
+    //
+    //        VideoResponseDTO.openResultDTO result = videoConverter.toOpenResultDTO(video);
+    //
+    //        return ApiResponse.onSuccess(result);
+    //    }
+    //
+    //    @PatchMapping("/to_close")
+    //    @Operation(summary = "비디오를 공개에서 비공개로 전환", description = "")
+    //    public ApiResponse<VideoResponseDTO.openResultDTO> toCloseVideo(
+    //            @AuthenticationPrincipal CustomUserDetails userDetails,
+    //            @RequestParam(required = true) Long videoId) {
+    //        // 현재 로그인한 사용자가 크리에이터가 맞는지 확인
+    //        User user = userDetails.getUser();
+    //
+    //        Video video = videoService.closeVideo(videoId, user);
+    //
+    //        VideoResponseDTO.openResultDTO result = videoConverter.toOpenResultDTO(video);
+    //
+    //        return ApiResponse.onSuccess(result);
+    //    }
+
+    @PatchMapping("/modify")
+    @Operation(
+            summary = "비디오의 정보를 수정",
+            description = "영상의 title, detail, thumbnailUrl, isOpen을 수정합니다.")
+    public ApiResponse<VideoResponseDTO.modifyResultDTO> modifyVideoInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(required = true) Long videoId) {
+            @RequestBody(required = true) VideoRequestDTO.modifyRequestDTO request) {
         // 현재 로그인한 사용자가 크리에이터가 맞는지 확인
         User user = userDetails.getUser();
 
-        Video video = videoService.openVideo(videoId, user);
+        Video video = videoService.modifyVideo(request, user);
 
-        VideoResponseDTO.openResultDTO result = videoConverter.toOpenResultDTO(video);
-
-        return ApiResponse.onSuccess(result);
-    }
-
-    @PatchMapping("/to_close")
-    @Operation(summary = "비디오를 공개에서 비공개로 전환", description = "")
-    public ApiResponse<VideoResponseDTO.openResultDTO> toCloseVideo(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(required = true) Long videoId) {
-        // 현재 로그인한 사용자가 크리에이터가 맞는지 확인
-        User user = userDetails.getUser();
-
-        Video video = videoService.closeVideo(videoId, user);
-
-        VideoResponseDTO.openResultDTO result = videoConverter.toOpenResultDTO(video);
+        VideoResponseDTO.modifyResultDTO result = videoConverter.toModifyResultDTO(video);
 
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/TokenUs/TokenUs_BE/converter/NftConverter.java
+++ b/src/main/java/TokenUs/TokenUs_BE/converter/NftConverter.java
@@ -45,6 +45,25 @@ public class NftConverter {
                 .build();
     }
 
+    public Nft toNft_V2(
+            NftRequestDTO.NFTMintRequestGetDTO dto,
+            BigInteger tokenId,
+            Long userId,
+            String nftName,
+            String nftSymbol) {
+        return Nft.builder()
+                .tokenId(tokenId)
+                .nftName(nftName)
+                .nftSymbol(nftSymbol)
+                .currentPrice(BigInteger.ZERO) // 민팅 시엔 기본 0
+                .mintPrice(dto.getPrice())
+                .mintQuantity(dto.getTotalSupply())
+                .isListed(false) // 민팅 시엔 기본 false
+                .owner(userRepository.getReferenceById(userId))
+                .video(videoRepository.getReferenceById(dto.getVideoId().longValue()))
+                .build();
+    }
+
     public List<NftResponseDTO.NFTInfoDTO> toDTOList(List<Nft> nftList) {
         return nftList.stream()
                 .map(

--- a/src/main/java/TokenUs/TokenUs_BE/converter/VideoConverter.java
+++ b/src/main/java/TokenUs/TokenUs_BE/converter/VideoConverter.java
@@ -113,6 +113,17 @@ public class VideoConverter {
                 .build();
     }
 
+    public static VideoResponseDTO.modifyResultDTO toModifyResultDTO(Video video) {
+        return VideoResponseDTO.modifyResultDTO
+                .builder()
+                .id(video.getId())
+                .videoTitle(video.getTitle())
+                .videoDetail(video.getDetail())
+                .thumbnailUrl(video.getThumbnailUrl())
+                .isOpened(video.getIsOpen())
+                .build();
+    }
+
     public static VideoResponseDTO.getDetailDTO toDetailDTO(
             Video video, Long likeCount, Boolean isLiked) {
         // mintPrice와 floorPrice 계산

--- a/src/main/java/TokenUs/TokenUs_BE/converter/VideoConverter.java
+++ b/src/main/java/TokenUs/TokenUs_BE/converter/VideoConverter.java
@@ -120,7 +120,7 @@ public class VideoConverter {
                 .videoTitle(video.getTitle())
                 .videoDetail(video.getDetail())
                 .thumbnailUrl(video.getThumbnailUrl())
-                .isOpened(video.getIsOpen())
+                .isOpen(video.getIsOpen())
                 .build();
     }
 

--- a/src/main/java/TokenUs/TokenUs_BE/dto/NftRequestDTO.java
+++ b/src/main/java/TokenUs/TokenUs_BE/dto/NftRequestDTO.java
@@ -57,6 +57,19 @@ public class NftRequestDTO {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class listNftResultGetDTO {
+        private BigInteger tokenId;
+        private BigInteger price; // wei 단위
+        private String txHash;
+        private String creatorAddress;
+        private String creatorId; // 프론트에서 넣어주세요
+    }
+
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class NftDelistRequestDTO {
         private BigInteger tokenId;
     }

--- a/src/main/java/TokenUs/TokenUs_BE/dto/NftRequestDTO.java
+++ b/src/main/java/TokenUs/TokenUs_BE/dto/NftRequestDTO.java
@@ -1,11 +1,13 @@
 package TokenUs.TokenUs_BE.dto;
 
 import java.math.BigInteger;
+import java.util.List;
 
 import lombok.*;
 
 public class NftRequestDTO {
 
+    // emit VideoNFTMinted(videoId, creatorAddress, totalSupply, nftName, nftSymbol, price);
     @Builder
     @Getter
     @Setter
@@ -21,6 +23,23 @@ public class NftRequestDTO {
 
         // 클라이언트가 보내지 않지만 백엔드에서 주입될 값들
         private String creatorAddress;
+    }
+
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NFTMintRequestGetDTO {
+        private BigInteger totalSupply;
+        private String nftName;
+        private String nftSymbol;
+        private BigInteger price;
+        private BigInteger videoId;
+        private String creatorAddress;
+        private Long creatorId;
+        private String txHash;
+        private List<BigInteger> tokenIdList;
     }
 
     @Builder

--- a/src/main/java/TokenUs/TokenUs_BE/dto/NftRequestDTO.java
+++ b/src/main/java/TokenUs/TokenUs_BE/dto/NftRequestDTO.java
@@ -82,4 +82,16 @@ public class NftRequestDTO {
     public static class NFTPurchaseRequestDTO {
         private BigInteger tokenId;
     }
+
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NFTPurchaseResultGetDTO {
+        private BigInteger tokenId;
+        private String txHash;
+        private String buyerAddress; // 구매자의 지갑 주소
+        private BigInteger tradePrice; // 거래 가격 (wei 단위)
+    }
 }

--- a/src/main/java/TokenUs/TokenUs_BE/dto/NftResponseDTO.java
+++ b/src/main/java/TokenUs/TokenUs_BE/dto/NftResponseDTO.java
@@ -87,6 +87,19 @@ public class NftResponseDTO {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
+    public static class NFTPurchaseResultGetDTO {
+        private String txHash;
+        private BigInteger tokenId;
+        private String nftName;
+        private String nftSymbol;
+        private String buyerAddress;
+        private BigInteger tradePrice;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class NFTTradeHistoryDTO {
         private String txHash;
         private BigInteger tradePrice;

--- a/src/main/java/TokenUs/TokenUs_BE/dto/VideoRequestDTO.java
+++ b/src/main/java/TokenUs/TokenUs_BE/dto/VideoRequestDTO.java
@@ -29,4 +29,17 @@ public class VideoRequestDTO {
 
         private String videoUrl;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class modifyRequestDTO {
+
+        private Long videoId;
+        private String videoTitle;
+        private String videoDetail;
+        private String thumbnailUrl;
+        private Boolean isOpen;
+    }
 }

--- a/src/main/java/TokenUs/TokenUs_BE/dto/VideoResponseDTO.java
+++ b/src/main/java/TokenUs/TokenUs_BE/dto/VideoResponseDTO.java
@@ -82,6 +82,19 @@ public class VideoResponseDTO {
 
     @Builder
     @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class modifyResultDTO {
+
+        private Long id;
+        private String videoTitle;
+        private String videoDetail;
+        private String thumbnailUrl;
+        private Boolean isOpen;
+    }
+
+    @Builder
+    @Getter
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/java/TokenUs/TokenUs_BE/service/NftService.java
+++ b/src/main/java/TokenUs/TokenUs_BE/service/NftService.java
@@ -152,6 +152,47 @@ public class NftService {
                 .build();
     }
 
+    public NftResponseDTO.NFTMintResultDTO mintResultGet(NftRequestDTO.NFTMintRequestGetDTO request)
+            throws Exception {
+
+        List<BigInteger> tokenIdList = request.getTokenIdList();
+
+        List<Nft> savedNfts = new ArrayList<>();
+
+        for (BigInteger tokenId : tokenIdList) {
+            Nft nft =
+                    nftConverter.toNft_V2(
+                            request,
+                            tokenId,
+                            request.getCreatorId(),
+                            request.getNftName(),
+                            request.getNftSymbol());
+
+            nft = nftRepository.save(nft); // 저장된 엔티티 다시 할당
+
+            savedNfts.add(nft);
+
+            Transaction transaction =
+                    Transaction.builder()
+                            .txHash(request.getTxHash())
+                            .type(TransactionType.MINT)
+                            .seller(userRepository.getReferenceById(request.getCreatorId()))
+                            .buyer(null)
+                            .nft(nft)
+                            .build();
+
+            transactionRepository.save(transaction);
+        }
+
+        // 4. 응답 DTO 구성
+        List<NftResponseDTO.NFTInfoDTO> nftInfos = nftConverter.toDTOList(savedNfts);
+
+        return NftResponseDTO.NFTMintResultDTO.builder()
+                .transactionHash(request.getTxHash())
+                .mintedNFTs(nftInfos)
+                .build();
+    }
+
     private List<BigInteger> extractTokenIdsFromLogs(TransactionReceipt receipt) {
         List<BigInteger> tokenIds = new ArrayList<>();
 

--- a/src/main/java/TokenUs/TokenUs_BE/service/NftService.java
+++ b/src/main/java/TokenUs/TokenUs_BE/service/NftService.java
@@ -535,7 +535,7 @@ public class NftService {
                         .orElseThrow(() -> new IllegalArgumentException("NFT를 찾을 수 없습니다."));
 
         nft.setIsListed(false);
-        nft.setCurrentPrice(price);
+        nft.setCurrentPrice(null);
 
         User buyer =
                 userRepository
@@ -651,6 +651,49 @@ public class NftService {
     //                .tradePrice(price)
     //                .build();
     //    }
+
+    public NftResponseDTO.NFTPurchaseResultGetDTO purchaseNftResultGet(
+            NftRequestDTO.NFTPurchaseResultGetDTO request) throws Exception {
+
+        BigInteger tokenId = request.getTokenId();
+
+        // 📦 DB 업데이트
+        Nft nft =
+                nftRepository
+                        .findByTokenId(tokenId)
+                        .orElseThrow(() -> new IllegalArgumentException("NFT를 찾을 수 없습니다."));
+
+        nft.setIsListed(false);
+        nft.setCurrentPrice(null);
+
+        User buyer =
+                userRepository
+                        .findByWalletAddress(request.getBuyerAddress())
+                        .orElseThrow(() -> new IllegalArgumentException("해당 지갑의 유저가 존재하지 않습니다."));
+        nft.setOwner(buyer);
+        nftRepository.save(nft);
+
+        // 🧾 트랜잭션 저장
+        Transaction transaction =
+                Transaction.builder()
+                        .txHash(request.getTxHash())
+                        .type(TransactionType.TRADE)
+                        .seller(nft.getOwner())
+                        .buyer(buyer)
+                        .tradePrice(request.getTradePrice())
+                        .nft(nft)
+                        .build();
+        transactionRepository.save(transaction);
+
+        return NftResponseDTO.NFTPurchaseResultGetDTO.builder()
+                .txHash(request.getTxHash())
+                .tokenId(tokenId)
+                .nftName(nft.getNftName())
+                .nftSymbol(nft.getNftSymbol())
+                .buyerAddress(request.getBuyerAddress())
+                .tradePrice(request.getTradePrice())
+                .build();
+    }
 
     public List<NftResponseDTO.NFTTradeHistoryDTO> getTradeHistoryByVideoId(Long videoId) {
         List<Transaction> transactions =

--- a/src/main/java/TokenUs/TokenUs_BE/service/NftService.java
+++ b/src/main/java/TokenUs/TokenUs_BE/service/NftService.java
@@ -289,6 +289,80 @@ public class NftService {
                 .build();
     }
 
+    public NftResponseDTO.NFTListResultDTO listNftResultGet(
+            NftRequestDTO.listNftResultGetDTO request) throws Exception {
+
+        Nft nft =
+                nftRepository
+                        .findByTokenId(request.getTokenId())
+                        .orElseThrow(
+                                () -> new IllegalArgumentException("해당 tokenId의 NFT가 존재하지 않습니다."));
+
+        nft.setIsListed(true);
+        nft.setCurrentPrice(request.getPrice());
+        nftRepository.save(nft);
+
+        // 🧾 트랜잭션 기록
+        Transaction transaction =
+                Transaction.builder()
+                        .txHash(request.getTxHash())
+                        .type(TransactionType.LIST)
+                        .seller(nft.getOwner())
+                        .buyer(null)
+                        .nft(nft)
+                        .build();
+        transactionRepository.save(transaction);
+
+        return NftResponseDTO.NFTListResultDTO.builder()
+                .id(nft.getId())
+                .transactionHash(request.getTxHash())
+                .nftName(nft.getNftName())
+                .nftSymbol(nft.getNftSymbol())
+                .tokenId(request.getTokenId())
+                .currentPrice(nft.getCurrentPrice())
+                .mintPrice(nft.getMintPrice())
+                .sellerAddress(nft.getOwner().getWalletAddress())
+                .isListed(true)
+                .build();
+    }
+
+    public NftResponseDTO.NFTListResultDTO delistNftResultGet(
+            NftRequestDTO.listNftResultGetDTO request) throws Exception {
+
+        Nft nft =
+                nftRepository
+                        .findByTokenId(request.getTokenId())
+                        .orElseThrow(
+                                () -> new IllegalArgumentException("해당 tokenId의 NFT가 존재하지 않습니다."));
+
+        nft.setIsListed(false);
+        nft.setCurrentPrice(request.getPrice());
+        nftRepository.save(nft);
+
+        // 🧾 트랜잭션 기록
+        Transaction transaction =
+                Transaction.builder()
+                        .txHash(request.getTxHash())
+                        .type(TransactionType.DELIST)
+                        .seller(nft.getOwner())
+                        .buyer(null)
+                        .nft(nft)
+                        .build();
+        transactionRepository.save(transaction);
+
+        return NftResponseDTO.NFTListResultDTO.builder()
+                .id(nft.getId())
+                .transactionHash(request.getTxHash())
+                .nftName(nft.getNftName())
+                .nftSymbol(nft.getNftSymbol())
+                .tokenId(request.getTokenId())
+                .currentPrice(nft.getCurrentPrice())
+                .mintPrice(nft.getMintPrice())
+                .sellerAddress(nft.getOwner().getWalletAddress())
+                .isListed(false)
+                .build();
+    }
+
     public List<NftResponseDTO.listedNFTInfoDTO> getListedNfts(Long loginUserId) throws Exception {
         System.out.println("[SERVICE] getListedNfts() 호출됨");
 

--- a/src/main/java/TokenUs/TokenUs_BE/service/VideoService.java
+++ b/src/main/java/TokenUs/TokenUs_BE/service/VideoService.java
@@ -137,6 +137,26 @@ public class VideoService {
         return video;
     }
 
+    public Video modifyVideo(VideoRequestDTO.modifyRequestDTO request, User user) {
+        // 영상이 존재하는지 검증
+        Video video =
+                videoRepository
+                        .findById(request.getVideoId())
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_YOUR_VIDEO));
+
+        // 로그인한 사용자의 영상이 맞는지 검증
+        if (!video.getCreator().getId().equals(user.getId())) {
+            throw new GeneralException(ErrorStatus.NOT_YOUR_VIDEO);
+        }
+
+        video.setTitle(request.getVideoTitle());
+        video.setDetail(request.getVideoDetail());
+        video.setThumbnailUrl(request.getThumbnailUrl());
+        video.setIsOpen(request.getIsOpen());
+        videoRepository.save(video);
+        return video;
+    }
+
     @Transactional
     public void increaseView(Long videoId) {
         Video video =


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## ⭐Related Issues
- closes #177 


## 변경 사항
> nft 발행, 판매 등록, 거래의 스마트 컨트랙트 호출을 FE에서 하도록 API 변겅

## 테스트 결과
<img width="606" alt="nft:mint_result" src="https://github.com/user-attachments/assets/2b116cf6-979e-4dca-8d92-6b8ad8b8e9c0" />

<img width="606" alt="image" src="https://github.com/user-attachments/assets/38e8ab0b-311f-4065-81cb-0a22f4fa2283" />

<img width="606" alt="image" src="https://github.com/user-attachments/assets/c753b0e8-8484-4cfa-ac50-6390633793d5" />

## Must do
- [ ] checked assignees
- [ ] checked labels
